### PR TITLE
Updated passing oauth token into listener function

### DIFF
--- a/src/Spinegar/Sugar7Wrapper/Rest.php
+++ b/src/Spinegar/Sugar7Wrapper/Rest.php
@@ -88,9 +88,10 @@ class Rest {
       return false;
 
     $this->token = $results['access_token'];
-
-    $this->client->getEventDispatcher()->addListener('request.before_send', function(Event $event) {
-      $event['request']->setHeader('OAuth-Token', $this->token);
+    $token = $this->token;
+    
+    $this->client->getEventDispatcher()->addListener('request.before_send', function(Event $event) use ($token) {
+      $event['request']->setHeader('OAuth-Token', $token);
     });
     
     return true;


### PR DESCRIPTION
When using this library out of the box, php threw an object access error regarding the use of $this->token from within the context of the new anonymous function.  Passing in the token via 'use' works fine.
