### PR TITLE
Adding a way to send options (aka DefaultOptions) to Guzzle. This came i...

### DIFF
--- a/src/Spinegar/Sugar7Wrapper/Rest.php
+++ b/src/Spinegar/Sugar7Wrapper/Rest.php
@@ -112,6 +112,19 @@ class Rest {
   }
 
   /**
+  * Function: setClientOptions()
+  * Parameters:   $key = Guzzle option, $value = Value  
+  * Description:  Set Default options for the Guzzle client.
+  * Returns:  returns $this
+  */
+  public function setClientOption($key, $value)
+  {
+    $this->client->setDefaultOption($key, $value);
+
+    return $this;
+  }
+
+  /**
   * Function: setUrl()
   * Parameters:   $value = URL for the REST API    
   * Description:  Set $url


### PR DESCRIPTION
...n 3.7.0 which means this is not compatible with master right now, since it specifies 3.1.1 in composer.json.

As comment hints, do not just pull this, it's more for later use or informational for people needing this functionality.
