### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "v3.8.0"
+        "guzzle/guzzle": "v3.8.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
They fixed in 3.8.1 this problem:

Warning: curl_multi_info_read(): 560 is not a valid cURL Multi Handle resource in Guzzle\Http\Curl\CurlMulti->processMessages() (line 241 of /vendor/guzzle/guzzle/src/Guzzle/Http/Curl/CurlMulti.php).
