### PR TITLE
allow users to login through multiple platforms

### DIFF
--- a/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
+++ b/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
@@ -77,6 +77,7 @@ class Guzzle implements ClientInterface {
         'client_id' => 'sugar',
         'username' => $this->username,
         'password' => $this->password,
+        'platform' => 'api',
     ));
 
     $result = $request->send()->json();


### PR DESCRIPTION
Adding the platform when retrieving the token will allow the user to maintain their login through the application and be logged in through the API client as well.

This can honestly be set to any value other then the client types (base, portal, mobile) just though api made sense as a default.

I finally figured this out by diving through some of the oauth code and then like two days later I saw a post on the developer blog. http://developer.sugarcrm.com/2014/06/20/how-to-avoid-logging-out-a-user-when-using-their-credentials-via-the-new-rest-api/
