### PR TITLE
Missed required settings by rfc which genereates PHP Notice

### DIFF
--- a/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
+++ b/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
@@ -75,6 +75,7 @@ class Guzzle implements ClientInterface {
     $request = $this->client->post('oauth2/token', null, array(
         'grant_type' => 'password',
         'client_id' => 'sugar',
+        'client_secret' => '',
         'username' => $this->username,
         'password' => $this->password,
         'platform' => 'api',


### PR DESCRIPTION
The AOuth spec requires client_id and client_secret and the PHP library used by Sugar check both of these variables in file vendor/oauth2-php/lib/OAuth2.php on line 774. The current result without this setting is a PHP notice on Sugar instance "PHP Notice:  Undefined index: client_secret"
