### PR TITLE
added support for multiple requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ $sugar->download('Notes', $record_id, 'filename', '/path/to/destination.ext');
 
 /* Upload a file associated to the filename field of a note to the server */
 $sugar->upload('Notes', $record_id, 'filename', '/path/of/local/file.ext');
+
+/* Sending multiple requests */
+$results = $this->client->send(function($client){
+	return [
+		$client->countRecords('Cases'),
+		$client->countRecords('Cases'),
+		$client->countRecords('Cases'),
+	];
+});
 ```
 
 4. Custom & Undefined Endpoints

--- a/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
+++ b/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
@@ -51,6 +51,12 @@ class Guzzle implements ClientInterface {
   protected $client;
 
   /**
+  * Variable: $resolve
+  * Description:  Determines if request should be made immediately or request object returned. used for multi request.
+  */
+  protected $resolve = true;
+
+  /**
   * Function: __construct()
   * Parameters:   none    
   * Description:  Construct Class
@@ -240,6 +246,21 @@ class Guzzle implements ClientInterface {
 
     return true;
   }
+/**
+  * Function: send()
+  * Parameters:   $callback = function(Rest $client): Array<Request>, Rest $api       
+  * Description:  send multiple requests with curl_multi_exec
+  * Returns:  ARRAY of response arrays
+  */
+    public function send($callback, $api)
+    {
+        $this->resolve = false;
+        $results =  $this->client->send($callback($api));
+        $this->resolve = true;
+        $results = array_filter($results, function($response){ return $response; });
+        return array_map(function($response) { return $response->json(); }, $results);
+
+    }
 
   /**
   * Function: get()
@@ -261,6 +282,10 @@ class Guzzle implements ClientInterface {
     foreach($parameters as $key=>$value)
     {
       $query->add($key, $value);
+    }
+
+    if (!$this->resolve) {
+      return $request;
     }
 
     $response = $request->send()->json();
@@ -341,6 +366,11 @@ class Guzzle implements ClientInterface {
       self::connect();
 
     $request = $this->client->post($endpoint, null, json_encode($parameters));
+
+    if (!$this->resolve) {
+      return $request;
+    }
+
     $response = $request->send()->json();
 
     if(!$response)
@@ -363,6 +393,11 @@ class Guzzle implements ClientInterface {
       self::connect();
 
     $request = $this->client->put($endpoint, null, json_encode($parameters));
+
+    if (!$this->resolve) {
+      return $request;
+    }
+
     $response = $request->send()->json();
 
     if(!$response)
@@ -384,6 +419,11 @@ class Guzzle implements ClientInterface {
       self::connect();
 
     $request = $this->client->delete($endpoint);
+
+    if (!$this->resolve) {
+      return $request;
+    }
+    
     $response = $request->send()->json();
 
 

--- a/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
+++ b/src/Spinegar/Sugar7Wrapper/Clients/Guzzle.php
@@ -257,8 +257,19 @@ class Guzzle implements ClientInterface {
         $this->resolve = false;
         $results =  $this->client->send($callback($api));
         $this->resolve = true;
-        $results = array_filter($results, function($response){ return $response; });
-        return array_map(function($response) { return $response->json(); }, $results);
+        return array_map(function($response) {
+
+          if (!$response) {
+            return false;
+          }
+
+          try {
+              return $response->json(); 
+          } catch (Exception $e) {
+            return false;
+          }
+          
+          }, $results);
 
     }
 
@@ -321,6 +332,10 @@ class Guzzle implements ClientInterface {
 
     $request->setResponseBody($destinationFile);
 
+    if (!$this->resolve) {
+      return $request;
+    }
+
     $response = $request->send();
 
     if(!$response)
@@ -344,6 +359,11 @@ class Guzzle implements ClientInterface {
 
     $request = $this->client->post($endpoint, array(), $parameters);
     $request->setHeader('Content-Type', 'multipart/form-data');
+
+    if (!$this->resolve) {
+      return $request;
+    }
+
     $result = $request->send();
 
     if(!$result)

--- a/src/Spinegar/Sugar7Wrapper/Rest.php
+++ b/src/Spinegar/Sugar7Wrapper/Rest.php
@@ -37,6 +37,17 @@ class Rest {
     return $this->client->connect();
   }
 
+ /**
+  * Function: send()
+  * Parameters:   $callback = function(Rest $client): Array<Request>    
+  * Description:  send multiple requests with curl_multi_exec
+  * Returns:  ARRAY of response arrays
+  */
+  public function send($callback)
+  {
+      return $this->client->send($callback, $this);
+  }
+
   /**
   * Function: check()
   * Parameters:   none    

--- a/tests/Sugar7Wrapper.php
+++ b/tests/Sugar7Wrapper.php
@@ -9,7 +9,7 @@ class Sugar7WrapperTest extends \PHPUnit_Framework_TestCase
     private $host = 'https://sugar/rest/v10/';
     private $username = 'username';
     private $password = 'password';
-
+    
     function __construct()
     {
         $this->client = new Rest();
@@ -227,5 +227,22 @@ class Sugar7WrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($res));
         $this->assertTrue(array_key_exists('record_count', $res));
         $this->assertTrue(is_numeric($res['record_count']));
+    }
+
+    public function testMultipleRequests()
+    {
+        $results = $this->client->send(function($client){
+            return [
+                $client->countRecords('Cases'),
+                $client->countRecords('Cases'),
+                $client->countRecords('Cases'),
+            ];
+        });
+
+        foreach($results as $res) {
+            $this->assertTrue(is_array($res));
+            $this->assertTrue(array_key_exists('record_count', $res));
+            $this->assertTrue(is_numeric($res['record_count']));
+        }
     }
 }


### PR DESCRIPTION
Among other things, I was using this API client for load testing. I added multi-request support to make that easier and I figured I'd contribute it back to the main repo. Also, I have only tested this with get requests but other tests continue to pass.